### PR TITLE
fix the example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,14 @@ of the node.
 Example:
 
 ```
+# Import the module first
 Import-Module .\Show-Ast.psm1
+
+# Show the ast of a script or script module
+Show-Ast $pshome\Modules\Microsoft.PowerShell.Utility\Microsoft.PowerShell.Utility.psm1
+Show-Ast ~\Documents\WindowsPowerShell\profile.ps1
+
+# Show the ast of a script block
 Show-Ast { echo -InputObject "Name is $name" }.Ast
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ of the node.
 Example:
 
 ```
-Show-Ast .\Show-Ast.psm1
+Import-Module .\Show-Ast.psm1
 Show-Ast { echo -InputObject "Name is $name" }.Ast
 ```
 


### PR DESCRIPTION
The example commands in the README.md does not appear to be correct. This PR fixes it. 

Signed-off-by: Satoshi Tanda <tanda.sat@gmail.com>